### PR TITLE
Allow to take pictures on device without builtin camera

### DIFF
--- a/libpretixui-android/src/main/java/eu/pretix/libpretixui/android/questions/QuestionsDialog.kt
+++ b/libpretixui-android/src/main/java/eu/pretix/libpretixui/android/questions/QuestionsDialog.kt
@@ -361,7 +361,7 @@ class QuestionsDialog(
                     llFormFields.addView(fieldB)
                 }
                 QuestionType.F -> {
-                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || !ctx.packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA)) {
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
                         val tv = TextView(ctx)
                         tv.text = "Not supported on this Android version or device"
                         llFormFields.addView(tv)


### PR DESCRIPTION
…otherwise, no chance to take a picture with USB on a device with no camera.

@robbi5 Do you have devices with no camera at all to verify that it doesn't crash on them? I tested on the HP, but the HP has… inconsistent opinions of whether or not it has a camera