### PR TITLE
Use ContextCompat for HardwareScanner Intent Receiver Registration

### DIFF
--- a/libpretixui-android/src/main/java/eu/pretix/libpretixui/android/scanning/HardwareScanner.kt
+++ b/libpretixui-android/src/main/java/eu/pretix/libpretixui/android/scanning/HardwareScanner.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
 import android.util.Log
+import androidx.core.content.ContextCompat
 
 
 interface ScanReceiver {
@@ -83,7 +84,7 @@ class HardwareScanner(val receiver: ScanReceiver) {
         filter.addAction("com.android.scanner.ACTION_DATA_CODE_RECEIVED")
         filter.addAction("com.sunmi.scanner.ACTION_DATA_CODE_RECEIVED")
 
-        ctx.registerReceiver(scanReceiver, filter)
+        ContextCompat.registerReceiver(ctx, scanReceiver, filter, ContextCompat.RECEIVER_EXPORTED)
     }
 
     fun stop(ctx: Context) {


### PR DESCRIPTION
This allows to set RECEIVER_EXPORTED correctly for SDK>=26 (Having that flag is enforced for Android 14+)