### PR TITLE
ZXing: Ignore ArrayIndexOutOfBoundsException

### DIFF
--- a/libpretixui-android/src/main/java/eu/pretix/libpretixui/android/scanning/ScannerView.kt
+++ b/libpretixui-android/src/main/java/eu/pretix/libpretixui/android/scanning/ScannerView.kt
@@ -263,6 +263,8 @@ class ScannerView : FrameLayout {
                     listener.handleResult(Result(rawResult.text, rawResult.rawBytes))
                 } catch (e: NotFoundException) {
                     // ignore, no barcode found
+                } catch (e: ArrayIndexOutOfBoundsException) {
+                    // ignore, this is something zxing seems to do if it does not like the barcode
                 } finally {
                     multiFormatReader.reset()
                     image.close()


### PR DESCRIPTION
See internal sentry report: https://errors.rami.io/organizations/ramiio/issues/80572/

Looking at https://github.com/zxing/zxing/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aclosed+ArrayIndexOutOfBoundsException this is something zxing does if it can't parse the QR code correctly. Unfortunately, but not something we can fix and we'd rather not crash the app.