### PR TITLE
Allow to use the front camera

### DIFF
--- a/libpretixui-android/src/main/java/eu/pretix/libpretixui/android/scanning/ScannerView.kt
+++ b/libpretixui-android/src/main/java/eu/pretix/libpretixui/android/scanning/ScannerView.kt
@@ -6,7 +6,6 @@ import android.graphics.ImageFormat
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraMetadata
 import android.hardware.camera2.CaptureRequest
-import android.preference.PreferenceManager
 import android.util.AttributeSet
 import android.util.Size
 import android.view.OrientationEventListener

--- a/libpretixui-android/src/main/java/eu/pretix/libpretixui/android/scanning/ScannerView.kt
+++ b/libpretixui-android/src/main/java/eu/pretix/libpretixui/android/scanning/ScannerView.kt
@@ -6,6 +6,7 @@ import android.graphics.ImageFormat
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraMetadata
 import android.hardware.camera2.CaptureRequest
+import android.preference.PreferenceManager
 import android.util.AttributeSet
 import android.util.Size
 import android.view.OrientationEventListener
@@ -59,11 +60,17 @@ class ScannerView : FrameLayout {
     private var autofocusTarget: Boolean = true
     private var orientationEventListener: OrientationEventListener? = null
     private var camera: Camera? = null
+    private var preferFrontCameraTarget: Boolean = false
 
     constructor(context: Context) : super(context) {}
 
     constructor(context: Context, attributeSet: AttributeSet) : super(context, attributeSet) {}
 
+    var preferFrontCamera: Boolean
+        get() = preferFrontCameraTarget
+        set(value) {
+            preferFrontCameraTarget = value
+        }
     var torch: Boolean
         get() = torchTarget
         set(value) {
@@ -155,6 +162,10 @@ class ScannerView : FrameLayout {
         var cameraSelector = CameraSelector.Builder().build()
         if (cameraProvider.hasCamera(CameraSelector.DEFAULT_BACK_CAMERA)) {
             cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+        }
+
+        if (preferFrontCamera && cameraProvider.hasCamera(CameraSelector.DEFAULT_FRONT_CAMERA)) {
+            cameraSelector = CameraSelector.DEFAULT_FRONT_CAMERA
         }
 
         val imageAnalysis = ImageAnalysis.Builder()


### PR DESCRIPTION
Allow using the front facing camera to create low-cost kiosk using a basic android tablet. If the front camera is preferred, but not available, the fallback will be the back-facing camera. This would also allow to create a PR for the issue https://github.com/pretix/pretixscan-android/issues/119 and implement that as a feature.